### PR TITLE
Update README.md to have version specifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 **Kosho** creates and manages [git worktree]s in `.kosho/` directories, making it easy to work on multiple branches simultaneously without the overhead of cloning repositories or switching contexts.
 
 ```bash
-go install github.com/carlsverre/kosho
+go install github.com/carlsverre/kosho@latest
 ```
 
 ## Why Use Kosho?


### PR DESCRIPTION
Go gives me an warning when I try to install without a version specifier (b/c I'm not in a Go module)
```
go: 'go install' requires a version when current directory is not in a module
        Try 'go install github.com/carlsverre/kosho@latest' to install the latest version
```